### PR TITLE
Disable registry check on Mono.

### DIFF
--- a/src/Core/Utility/EnvironmentUtility.cs
+++ b/src/Core/Utility/EnvironmentUtility.cs
@@ -29,6 +29,11 @@ namespace NuGet
         {
             get
             {
+                if (_isMonoRuntime)
+                {
+                    return false;
+                }
+            
                 using (var baseKey = Microsoft.Win32.RegistryKey.OpenBaseKey(
                     Microsoft.Win32.RegistryHive.LocalMachine,
                     Microsoft.Win32.RegistryView.Registry32))


### PR DESCRIPTION
This is a workaround to fix bug #29088 - Custom NuGet feed package
operations fail.
https://bugzilla.xamarin.com/show_bug.cgi?id=29088

A DisableBuffering option was added for the NuGet.exe push command in
b0e55ac46689248329b2be5b31e5b001ddc44ab3

This new feature checked the registry to see if .NET 4.5 is installed.
With Mono 4.0 this caused a 'No access to the given key' error when
viewing a custom NuGet package source such as Team City. The problem
is that Mono 4.0 does not create the directory:

/Library/Frameworks/Mono.framework/Versions/4.0.0/etc/mono/registry/LocalMachine

The registry/LocalMachine part is missing.

To workaround this problem the registry check in NuGet is now disabled
when on Mono. If Mono 4.0 is changed to create the
registry/LocalMachine when it is installed then this change will not
be needed.

On Mono 4.0